### PR TITLE
Add support for custom Ktlint RuleSets

### DIFF
--- a/src/main/kotlin/org/jmailen/gradle/kotlinter/KotlinterPlugin.kt
+++ b/src/main/kotlin/org/jmailen/gradle/kotlinter/KotlinterPlugin.kt
@@ -1,16 +1,14 @@
 package org.jmailen.gradle.kotlinter
 
-import com.android.build.gradle.internal.tasks.factory.dependsOn
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.api.artifacts.Configuration
-import org.gradle.api.attributes.Usage
 import org.gradle.api.tasks.TaskProvider
-import org.jetbrains.kotlin.gradle.internal.Kapt3GradleSubplugin.Companion.isIncludeCompileClasspath
 import org.jmailen.gradle.kotlinter.pluginapplier.AndroidSourceSetApplier
 import org.jmailen.gradle.kotlinter.pluginapplier.KotlinJvmSourceSetApplier
 import org.jmailen.gradle.kotlinter.pluginapplier.KotlinMultiplatformSourceSetApplier
+import org.jmailen.gradle.kotlinter.support.ktlintRulesetsFromClasspath
 import org.jmailen.gradle.kotlinter.support.reporterFileExtension
 import org.jmailen.gradle.kotlinter.tasks.FormatTask
 import org.jmailen.gradle.kotlinter.tasks.InstallPreCommitHookTask

--- a/src/main/kotlin/org/jmailen/gradle/kotlinter/KotlinterPlugin.kt
+++ b/src/main/kotlin/org/jmailen/gradle/kotlinter/KotlinterPlugin.kt
@@ -8,7 +8,6 @@ import org.gradle.api.tasks.TaskProvider
 import org.jmailen.gradle.kotlinter.pluginapplier.AndroidSourceSetApplier
 import org.jmailen.gradle.kotlinter.pluginapplier.KotlinJvmSourceSetApplier
 import org.jmailen.gradle.kotlinter.pluginapplier.KotlinMultiplatformSourceSetApplier
-import org.jmailen.gradle.kotlinter.support.ktlintRulesetsFromClasspath
 import org.jmailen.gradle.kotlinter.support.reporterFileExtension
 import org.jmailen.gradle.kotlinter.tasks.FormatTask
 import org.jmailen.gradle.kotlinter.tasks.InstallPreCommitHookTask

--- a/src/main/kotlin/org/jmailen/gradle/kotlinter/pluginapplier/AndroidSourceSetApplier.kt
+++ b/src/main/kotlin/org/jmailen/gradle/kotlinter/pluginapplier/AndroidSourceSetApplier.kt
@@ -6,7 +6,6 @@ import com.android.build.gradle.BaseExtension
 import com.android.build.gradle.api.AndroidSourceSet
 import org.gradle.api.Project
 import org.gradle.api.file.FileTree
-import org.jetbrains.kotlin.cfg.pseudocode.and
 import org.jmailen.gradle.kotlinter.SourceSetAction
 import org.jmailen.gradle.kotlinter.SourceSetApplier
 import org.jmailen.gradle.kotlinter.id

--- a/src/main/kotlin/org/jmailen/gradle/kotlinter/pluginapplier/AndroidSourceSetApplier.kt
+++ b/src/main/kotlin/org/jmailen/gradle/kotlinter/pluginapplier/AndroidSourceSetApplier.kt
@@ -6,6 +6,7 @@ import com.android.build.gradle.BaseExtension
 import com.android.build.gradle.api.AndroidSourceSet
 import org.gradle.api.Project
 import org.gradle.api.file.FileTree
+import org.jetbrains.kotlin.cfg.pseudocode.and
 import org.jmailen.gradle.kotlinter.SourceSetAction
 import org.jmailen.gradle.kotlinter.SourceSetApplier
 import org.jmailen.gradle.kotlinter.id

--- a/src/main/kotlin/org/jmailen/gradle/kotlinter/support/RuleSets.kt
+++ b/src/main/kotlin/org/jmailen/gradle/kotlinter/support/RuleSets.kt
@@ -3,6 +3,9 @@ package org.jmailen.gradle.kotlinter.support
 import com.pinterest.ktlint.core.RuleProvider
 import com.pinterest.ktlint.core.RuleSetProviderV2
 import com.pinterest.ktlint.ruleset.experimental.ExperimentalRuleSetProvider
+import org.gradle.api.file.ConfigurableFileCollection
+import java.io.File
+import java.net.URLClassLoader
 import java.util.ServiceLoader
 
 internal fun resolveRuleProviders(
@@ -27,3 +30,12 @@ internal fun resolveRuleProviders(
 // https://github.com/jeremymailen/kotlinter-gradle/issues/101
 val defaultRuleSetProviders: List<RuleSetProviderV2> =
     ServiceLoader.load(RuleSetProviderV2::class.java).toList()
+        .also { println(it) }
+
+fun ktlintRulesetsFromClasspath(classpath: ConfigurableFileCollection): List<RuleSetProviderV2> {
+    // Load the files from the classpath into a new ClassLoader
+    @Suppress("DEPRECATION")
+    val fileUris = classpath.map { it.toURL() }.toTypedArray()
+    val classLoader = URLClassLoader(fileUris, Thread.currentThread().contextClassLoader)
+    return ServiceLoader.load(RuleSetProviderV2::class.java, classLoader).toList()
+}

--- a/src/main/kotlin/org/jmailen/gradle/kotlinter/support/RuleSets.kt
+++ b/src/main/kotlin/org/jmailen/gradle/kotlinter/support/RuleSets.kt
@@ -11,6 +11,7 @@ internal fun resolveRuleProviders(
     providers: Iterable<RuleSetProviderV2>,
     includeExperimentalRules: Boolean = false,
 ): Set<RuleProvider> = providers
+    .also { println("Resolved Providers: ${it.map { it.id }.toSet()}") }
     .asSequence()
     .filter { includeExperimentalRules || it !is ExperimentalRuleSetProvider }
     .sortedWith(
@@ -29,7 +30,6 @@ internal fun resolveRuleProviders(
 // https://github.com/jeremymailen/kotlinter-gradle/issues/101
 val defaultRuleSetProviders: List<RuleSetProviderV2> =
     ServiceLoader.load(RuleSetProviderV2::class.java).toList()
-        .also { println(it) }
 
 fun ktlintRulesetsFromClasspath(classpath: ConfigurableFileCollection): List<RuleSetProviderV2> {
     // Load the files from the classpath into a new ClassLoader

--- a/src/main/kotlin/org/jmailen/gradle/kotlinter/support/RuleSets.kt
+++ b/src/main/kotlin/org/jmailen/gradle/kotlinter/support/RuleSets.kt
@@ -4,7 +4,6 @@ import com.pinterest.ktlint.core.RuleProvider
 import com.pinterest.ktlint.core.RuleSetProviderV2
 import com.pinterest.ktlint.ruleset.experimental.ExperimentalRuleSetProvider
 import org.gradle.api.file.ConfigurableFileCollection
-import java.io.File
 import java.net.URLClassLoader
 import java.util.ServiceLoader
 

--- a/src/main/kotlin/org/jmailen/gradle/kotlinter/support/RuleSets.kt
+++ b/src/main/kotlin/org/jmailen/gradle/kotlinter/support/RuleSets.kt
@@ -11,7 +11,6 @@ internal fun resolveRuleProviders(
     providers: Iterable<RuleSetProviderV2>,
     includeExperimentalRules: Boolean = false,
 ): Set<RuleProvider> = providers
-    .also { println("Resolved Providers: ${it.map { it.id }.toSet()}") }
     .asSequence()
     .filter { includeExperimentalRules || it !is ExperimentalRuleSetProvider }
     .sortedWith(

--- a/src/main/kotlin/org/jmailen/gradle/kotlinter/tasks/ConfigurableKtLintTask.kt
+++ b/src/main/kotlin/org/jmailen/gradle/kotlinter/tasks/ConfigurableKtLintTask.kt
@@ -1,11 +1,13 @@
 package org.jmailen.gradle.kotlinter.tasks
 
+import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.FileCollection
 import org.gradle.api.file.ProjectLayout
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.MapProperty
 import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Classpath
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.Internal
@@ -25,6 +27,8 @@ abstract class ConfigurableKtLintTask(
     projectLayout: ProjectLayout,
     objectFactory: ObjectFactory,
 ) : SourceTask() {
+    @get:Classpath
+    val ruleSetsClassPath: ConfigurableFileCollection = objectFactory.fileCollection()
 
     @Input
     val experimentalRules: Property<Boolean> = objectFactory.property(default = DEFAULT_EXPERIMENTAL_RULES)

--- a/src/main/kotlin/org/jmailen/gradle/kotlinter/tasks/FormatTask.kt
+++ b/src/main/kotlin/org/jmailen/gradle/kotlinter/tasks/FormatTask.kt
@@ -33,12 +33,7 @@ open class FormatTask @Inject constructor(
 
     @TaskAction
     fun run(inputChanges: InputChanges) {
-        // Initialize a WorkQueue with process isolation with a classpath set from the provided RuleSets.
-        val workQueue = workerExecutor.processIsolation { spec ->
-            spec.classpath.setFrom(ruleSetsClassPath.files)
-        }
-
-        val result = with(workQueue) {
+        val result = with(workerExecutor.noIsolation()) {
             submit(FormatWorkerAction::class.java) { p ->
                 p.name.set(name)
                 p.files.from(source)
@@ -46,6 +41,7 @@ open class FormatTask @Inject constructor(
                 p.ktLintParams.set(getKtLintParams())
                 p.output.set(report)
                 p.changedEditorConfigFiles.from(getChangedEditorconfigFiles(inputChanges))
+                p.customRuleSetProviders.setFrom(ruleSetsClassPath)
             }
             runCatching { await() }
         }

--- a/src/main/kotlin/org/jmailen/gradle/kotlinter/tasks/FormatTask.kt
+++ b/src/main/kotlin/org/jmailen/gradle/kotlinter/tasks/FormatTask.kt
@@ -33,7 +33,12 @@ open class FormatTask @Inject constructor(
 
     @TaskAction
     fun run(inputChanges: InputChanges) {
-        val result = with(workerExecutor.noIsolation()) {
+        // Initialize a WorkQueue with process isolation with a classpath set from the provided RuleSets.
+        val workQueue = workerExecutor.processIsolation { spec ->
+            spec.classpath.setFrom(ruleSetsClassPath.files)
+        }
+
+        val result = with(workQueue) {
             submit(FormatWorkerAction::class.java) { p ->
                 p.name.set(name)
                 p.files.from(source)

--- a/src/main/kotlin/org/jmailen/gradle/kotlinter/tasks/LintTask.kt
+++ b/src/main/kotlin/org/jmailen/gradle/kotlinter/tasks/LintTask.kt
@@ -19,7 +19,6 @@ import org.jetbrains.kotlin.utils.addToStdlib.ifNotEmpty
 import org.jmailen.gradle.kotlinter.KotlinterExtension.Companion.DEFAULT_IGNORE_FAILURES
 import org.jmailen.gradle.kotlinter.support.KotlinterError
 import org.jmailen.gradle.kotlinter.support.LintFailure
-import org.jmailen.gradle.kotlinter.support.ktlintRulesetsFromClasspath
 import org.jmailen.gradle.kotlinter.tasks.lint.LintWorkerAction
 import java.io.File
 import javax.inject.Inject

--- a/src/main/kotlin/org/jmailen/gradle/kotlinter/tasks/LintTask.kt
+++ b/src/main/kotlin/org/jmailen/gradle/kotlinter/tasks/LintTask.kt
@@ -45,7 +45,12 @@ open class LintTask @Inject constructor(
 
     @TaskAction
     fun run(inputChanges: InputChanges) {
-        val result = with(workerExecutor.noIsolation()) {
+        // Initialize a WorkQueue with process isolation with a classpath set from the provided RuleSets.
+        val workQueue = workerExecutor.processIsolation { spec ->
+            spec.classpath.setFrom(ruleSetsClassPath.files)
+        }
+
+        val result = with(workQueue) {
             submit(LintWorkerAction::class.java) { p ->
                 p.name.set(name)
                 p.files.from(source)

--- a/src/main/kotlin/org/jmailen/gradle/kotlinter/tasks/format/FormatWorkerAction.kt
+++ b/src/main/kotlin/org/jmailen/gradle/kotlinter/tasks/format/FormatWorkerAction.kt
@@ -12,6 +12,7 @@ import org.jmailen.gradle.kotlinter.support.KotlinterError
 import org.jmailen.gradle.kotlinter.support.KtLintParams
 import org.jmailen.gradle.kotlinter.support.defaultRuleSetProviders
 import org.jmailen.gradle.kotlinter.support.editorConfigOverride
+import org.jmailen.gradle.kotlinter.support.ktlintRulesetsFromClasspath
 import org.jmailen.gradle.kotlinter.support.resetEditorconfigCacheIfNeeded
 import org.jmailen.gradle.kotlinter.support.resolveRuleProviders
 import org.jmailen.gradle.kotlinter.tasks.FormatTask
@@ -24,6 +25,7 @@ abstract class FormatWorkerAction : WorkAction<FormatWorkerParameters> {
     private val name: String = parameters.name.get()
     private val ktLintParams: KtLintParams = parameters.ktLintParams.get()
     private val output: File? = parameters.output.asFile.orNull
+    private val customRuleSetProviders = ktlintRulesetsFromClasspath(parameters.customRuleSetProviders)
 
     override fun execute() {
         resetEditorconfigCacheIfNeeded(
@@ -33,7 +35,7 @@ abstract class FormatWorkerAction : WorkAction<FormatWorkerParameters> {
 
         val fixes = mutableListOf<String>()
         try {
-            val ruleSets = resolveRuleProviders(defaultRuleSetProviders, ktLintParams.experimentalRules)
+            val ruleSets = resolveRuleProviders(defaultRuleSetProviders + customRuleSetProviders, ktLintParams.experimentalRules)
 
             files.forEach { file ->
                 val sourceText = file.readText()

--- a/src/main/kotlin/org/jmailen/gradle/kotlinter/tasks/format/FormatWorkerAction.kt
+++ b/src/main/kotlin/org/jmailen/gradle/kotlinter/tasks/format/FormatWorkerAction.kt
@@ -33,8 +33,9 @@ abstract class FormatWorkerAction : WorkAction<FormatWorkerParameters> {
 
         val fixes = mutableListOf<String>()
         try {
+            val ruleSets = resolveRuleProviders(defaultRuleSetProviders, ktLintParams.experimentalRules)
+
             files.forEach { file ->
-                val ruleSets = resolveRuleProviders(defaultRuleSetProviders, ktLintParams.experimentalRules)
                 val sourceText = file.readText()
                 val relativePath = file.toRelativeString(projectDirectory)
 

--- a/src/main/kotlin/org/jmailen/gradle/kotlinter/tasks/format/FormatWorkerParameters.kt
+++ b/src/main/kotlin/org/jmailen/gradle/kotlinter/tasks/format/FormatWorkerParameters.kt
@@ -1,8 +1,10 @@
 package org.jmailen.gradle.kotlinter.tasks.format
 
+import com.pinterest.ktlint.core.RuleSetProviderV2
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.Property
+import org.gradle.api.provider.SetProperty
 import org.gradle.workers.WorkParameters
 import org.jmailen.gradle.kotlinter.support.KtLintParams
 
@@ -13,4 +15,5 @@ interface FormatWorkerParameters : WorkParameters {
     val projectDirectory: RegularFileProperty
     val ktLintParams: Property<KtLintParams>
     val output: RegularFileProperty
+    val customRuleSetProviders: ConfigurableFileCollection
 }

--- a/src/main/kotlin/org/jmailen/gradle/kotlinter/tasks/format/FormatWorkerParameters.kt
+++ b/src/main/kotlin/org/jmailen/gradle/kotlinter/tasks/format/FormatWorkerParameters.kt
@@ -1,10 +1,8 @@
 package org.jmailen.gradle.kotlinter.tasks.format
 
-import com.pinterest.ktlint.core.RuleSetProviderV2
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.Property
-import org.gradle.api.provider.SetProperty
 import org.gradle.workers.WorkParameters
 import org.jmailen.gradle.kotlinter.support.KtLintParams
 

--- a/src/main/kotlin/org/jmailen/gradle/kotlinter/tasks/lint/LintWorkerAction.kt
+++ b/src/main/kotlin/org/jmailen/gradle/kotlinter/tasks/lint/LintWorkerAction.kt
@@ -38,9 +38,10 @@ abstract class LintWorkerAction : WorkAction<LintWorkerParameters> {
         var hasError = false
 
         try {
+            val ruleSets = resolveRuleProviders(defaultRuleSetProviders, ktLintParams.experimentalRules)
+
             reporters.onEach { it.beforeAll() }
             files.forEach { file ->
-                val ruleSets = resolveRuleProviders(defaultRuleSetProviders, ktLintParams.experimentalRules)
                 val relativePath = file.toRelativeString(projectDirectory)
                 reporters.onEach { it.before(relativePath) }
                 logger.debug("$name linting: $relativePath")

--- a/src/main/kotlin/org/jmailen/gradle/kotlinter/tasks/lint/LintWorkerAction.kt
+++ b/src/main/kotlin/org/jmailen/gradle/kotlinter/tasks/lint/LintWorkerAction.kt
@@ -13,6 +13,7 @@ import org.jmailen.gradle.kotlinter.support.KtLintParams
 import org.jmailen.gradle.kotlinter.support.LintFailure
 import org.jmailen.gradle.kotlinter.support.defaultRuleSetProviders
 import org.jmailen.gradle.kotlinter.support.editorConfigOverride
+import org.jmailen.gradle.kotlinter.support.ktlintRulesetsFromClasspath
 import org.jmailen.gradle.kotlinter.support.reporterFor
 import org.jmailen.gradle.kotlinter.support.reporterPathFor
 import org.jmailen.gradle.kotlinter.support.resetEditorconfigCacheIfNeeded
@@ -29,6 +30,7 @@ abstract class LintWorkerAction : WorkAction<LintWorkerParameters> {
     private val projectDirectory: File = parameters.projectDirectory.asFile.get()
     private val name: String = parameters.name.get()
     private val ktLintParams: KtLintParams = parameters.ktLintParams.get()
+    private val customRuleSetProviders = ktlintRulesetsFromClasspath(parameters.customRuleSetProviders)
 
     override fun execute() {
         resetEditorconfigCacheIfNeeded(
@@ -38,7 +40,7 @@ abstract class LintWorkerAction : WorkAction<LintWorkerParameters> {
         var hasError = false
 
         try {
-            val ruleSets = resolveRuleProviders(defaultRuleSetProviders, ktLintParams.experimentalRules)
+            val ruleSets = resolveRuleProviders(defaultRuleSetProviders + customRuleSetProviders, ktLintParams.experimentalRules)
 
             reporters.onEach { it.beforeAll() }
             files.forEach { file ->

--- a/src/main/kotlin/org/jmailen/gradle/kotlinter/tasks/lint/LintWorkerParameters.kt
+++ b/src/main/kotlin/org/jmailen/gradle/kotlinter/tasks/lint/LintWorkerParameters.kt
@@ -1,9 +1,11 @@
 package org.jmailen.gradle.kotlinter.tasks.lint
 
+import com.pinterest.ktlint.core.RuleSetProviderV2
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.MapProperty
 import org.gradle.api.provider.Property
+import org.gradle.api.provider.SetProperty
 import org.gradle.workers.WorkParameters
 import org.jmailen.gradle.kotlinter.support.KtLintParams
 import java.io.File
@@ -15,4 +17,5 @@ interface LintWorkerParameters : WorkParameters {
     val projectDirectory: RegularFileProperty
     val reporters: MapProperty<String, File>
     val ktLintParams: Property<KtLintParams>
+    val customRuleSetProviders: ConfigurableFileCollection
 }

--- a/src/main/kotlin/org/jmailen/gradle/kotlinter/tasks/lint/LintWorkerParameters.kt
+++ b/src/main/kotlin/org/jmailen/gradle/kotlinter/tasks/lint/LintWorkerParameters.kt
@@ -1,11 +1,9 @@
 package org.jmailen.gradle.kotlinter.tasks.lint
 
-import com.pinterest.ktlint.core.RuleSetProviderV2
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.MapProperty
 import org.gradle.api.provider.Property
-import org.gradle.api.provider.SetProperty
 import org.gradle.workers.WorkParameters
 import org.jmailen.gradle.kotlinter.support.KtLintParams
 import java.io.File

--- a/src/test/kotlin/org/jmailen/gradle/kotlinter/functional/AndroidProjectTest.kt
+++ b/src/test/kotlin/org/jmailen/gradle/kotlinter/functional/AndroidProjectTest.kt
@@ -12,6 +12,7 @@ import java.io.File
 internal class AndroidProjectTest : WithGradleTest.Android() {
 
     private lateinit var androidModuleRoot: File
+    private lateinit var ruleSetModuleRoot: File
 
     @Before
     fun setUp() {
@@ -59,6 +60,9 @@ internal class AndroidProjectTest : WithGradleTest.Android() {
                             }
                         }
                         
+                        dependencies {
+                            ktlintRuleset(project(":ktlint-ruleset"))
+                        }
                         """.trimIndent()
                     writeText(androidBuildScript)
                 }
@@ -76,6 +80,81 @@ internal class AndroidProjectTest : WithGradleTest.Android() {
                 }
                 resolve("src/flavorOne/kotlin/FlavorSourceSet.kt") {
                     writeText(kotlinClass("FlavorSourceSet"))
+                }
+            }
+            ruleSetModuleRoot = resolve("ktlint-ruleset") {
+                resolve("build.gradle") {
+                    // language=groovy
+                    val androidBuildScript =
+                        """
+                        plugins {
+                            id 'kotlin'
+                            id 'org.jmailen.kotlinter'
+                        }
+
+                        dependencies {
+                            implementation("com.pinterest.ktlint:ktlint-core:0.47.1")
+                        }
+                        """.trimIndent()
+
+                    writeText(androidBuildScript)
+                }
+                resolve("src/main/java/com/example/rules/CustomRuleSetProvider.kt") {
+                    // language=kotlin
+                    val customRuleSetProvider = """
+                        package com.example.rules
+                        
+                        import com.pinterest.ktlint.core.RuleProvider
+                        import com.pinterest.ktlint.core.RuleSetProviderV2
+                        
+                        class CustomRuleSetProvider : RuleSetProviderV2(
+                            id = "custom",
+                            about = NO_ABOUT
+                        ) {
+                            override fun getRuleProviders() = setOf(
+                                RuleProvider { NoVarRule() }
+                            )
+                        }
+
+                    """.trimIndent()
+
+                    writeText(customRuleSetProvider)
+                }
+                resolve("src/main/java/com/example/rules/NoVarRule.kt") {
+                    // language=kotlin
+                    val customRuleSetProvider = """
+                        package com.example.rules
+                        
+                        import com.pinterest.ktlint.core.Rule
+                        import com.pinterest.ktlint.core.ast.ElementType.VAR_KEYWORD
+                        import org.jetbrains.kotlin.com.intellij.lang.ASTNode
+                        
+                        public class NoVarRule : Rule("custom:no-var") {
+                        
+                            override fun beforeVisitChildNodes(
+                                node: ASTNode,
+                                autoCorrect: Boolean,
+                                emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit
+                            ) {
+                                if (node.elementType == VAR_KEYWORD) {
+                                    emit(node.startOffset, "Unexpected var, use val instead", false)
+                                }
+                            }
+                        }
+
+                    """.trimIndent()
+
+                    writeText(customRuleSetProvider)
+                }
+                resolve("src/main/resources/META-INF/services/com.pinterest.ktlint.core.RuleSetProvider") {
+                    val customRuleSetProvider = "com.example.rules.CustomRuleSetProvider"
+
+                    writeText(customRuleSetProvider)
+                }
+                resolve("src/main/resources/META-INF/services/com.pinterest.ktlint.core.RuleSetProviderV2") {
+                    val customRuleSetProvider = "com.example.rules.CustomRuleSetProvider"
+
+                    writeText(customRuleSetProvider)
                 }
             }
         }
@@ -96,6 +175,7 @@ internal class AndroidProjectTest : WithGradleTest.Android() {
     private val settingsFile =
         """
         rootProject.name = 'kotlinter'
-        include 'androidproject'
+        include ':androidproject'
+        include ':ktlint-ruleset'
         """.trimIndent()
 }


### PR DESCRIPTION
A temporary branch for custom rules support while waiting for https://github.com/jeremymailen/kotlinter-gradle/pull/279 to merge.

Usage:
```kotlin
buildscript {
  repositories {
    // ...
    maven { url "https://jitpack.io" }
  }
  
  dependencies {
    // ...
    classpath "io.karn:kotlinter-gradle:karn--enable-support-for-custom-rulesets-SNAPSHOT"
  }
}
```

If jitpack is down you can resolve via github:
```kotlin
buildscript {
  repositories {
    // ...
    maven {
      url "https://raw.githubusercontent.com/Karn/kotlinter-gradle/karn--enable-support-for-custom-rulesets-1/libs/"
      content {
        includeGroup("org.jmailen.gradle")
      }
    }
  }
  
  dependencies {
    // ...
    classpath "org.jmailen.gradle:kotlinter-gradle:3.12.0-local"
  }
}
```

Then add custom rulesets project

```kotlin
dependencies {
  // ...
  ktlintRuleset project(":build-ktlint-rules")
}
```